### PR TITLE
fix: hero slide transition

### DIFF
--- a/src/components/comp-hero-slider/CompHeroSlider.tsx
+++ b/src/components/comp-hero-slider/CompHeroSlider.tsx
@@ -19,7 +19,7 @@ export const CompHeroSlider: React.FC<IGenCompHeroSlider> = ({ slides }) => {
   >(undefined);
 
   const intervalRef = useRef<any>();
-  const refActiveSlide = useRef<number>();
+  const refActiveSlide = useRef<number>(0);
   const timePerSlide = 5000;
 
   useEffect(() => {


### PR DESCRIPTION
- The transition failed on the third slide, the transition is coming from the first slide because the current slide ref was to properly initialized. 